### PR TITLE
Setup problems fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "sensio/distribution-bundle": "~3.0",
         "sensio/framework-extra-bundle": "~3.0",
         "incenteev/composer-parameter-handler": "~2.0",
-        "doctrine/migrations": "1.0.*@dev",
+        "doctrine/migrations": "1.0.*",
         "doctrine/doctrine-migrations-bundle": "~2.0@dev",
         "doctrine/doctrine-fixtures-bundle": "~2.0@dev",
         "bmatzner/fontawesome-bundle": "~4.0",
@@ -32,7 +32,7 @@
         "stof/doctrine-extensions-bundle": "~1.1",
         "jms/security-extra-bundle": "~1.5",
         "tecnick.com/tcpdf": "6.0.*",
-        "zendframework/zend-ldap": "~2.3",
+        "zendframework/zend-ldap": "~2.5",
         "friendsofsymfony/rest-bundle": "1.*",
         "jms/serializer-bundle": "~0.13"
     },

--- a/src/Opit/OpitHrm/NotificationBundle/Entity/Notification.php
+++ b/src/Opit/OpitHrm/NotificationBundle/Entity/Notification.php
@@ -33,7 +33,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * "jp" = "Opit\OpitHrm\HiringBundle\Entity\JPNotification",
  * "applicant" = "Opit\OpitHrm\HiringBundle\Entity\ApplicantNotification"})
  */
-class Notification
+abstract class Notification
 {
     /**
      * @var integer

--- a/src/Opit/OpitHrm/StatusBundle/Entity/StatusWorkflow.php
+++ b/src/Opit/OpitHrm/StatusBundle/Entity/StatusWorkflow.php
@@ -33,7 +33,7 @@ use Opit\OpitHrm\StatusBundle\Entity\Status;
  *     "applicant" = "Opit\OpitHrm\HiringBundle\Entity\ApplicantStatusWorkflow"
  * })
  */
-class StatusWorkflow
+abstract class StatusWorkflow
 {
     /**
      * @ORM\Column(type="integer")


### PR DESCRIPTION
Composer updated and the Statusworkflow and Notifications classes in order to when setup a new instance of OpitHrm preventing the errors during installation.
1. Composer updated: The Zend's Ldap dependency's version number increased. Doctrine migration's version number fixed to use the correct format.
2. Statusworkflow class made to abstract class, cause the DiscriminatorMap works fine.
3. Notification class made to abstract class, cause the DiscriminatorMap works fine.
